### PR TITLE
`Request.base/2` config adjustment

### DIFF
--- a/lib/supabase/storage/request.ex
+++ b/lib/supabase/storage/request.ex
@@ -5,7 +5,8 @@ defmodule Supabase.Storage.Request do
   alias Supabase.Fetcher.Request
 
   def base(%Client{} = client, path) when is_binary(path) do
-    Request.new(client)
+    client
+    |> Request.new(decode_body?: true, parse_http_error?: true)
     |> Request.with_storage_url(path)
     |> Request.with_error_parser(Supabase.Storage.Error)
     |> Request.with_http_client(http_client())


### PR DESCRIPTION
## Problem

when using `supabase_storage` with `supabase_potion` `0.7`, we are receiving a malformed response in functions like `Supabase.Storage.File.create_signed_url/3`

## Solution

after [adjustments in `supabase_potion`](https://github.com/supabase-community/supabase-ex/pull/67), we should explicitly set `decode_body?` and `parse_http_error?` config to `true` when using `Supabase.Fetcher.Request`.

this PR adjusts this in `Request.base/2`.

## Rationale

`Request.base/2`, as the name implies, is used by lots of functions under the hood. implementing the adjustment there will ensure the behavior of requests when using `supabase_poition` `0.7` follows `0.6` — which I understand is the intended behavior.
