### PR TITLE
fix: vector buckets api wire format

### DIFF
--- a/lib/supabase/storage/vector.ex
+++ b/lib/supabase/storage/vector.ex
@@ -140,9 +140,9 @@ defmodule Supabase.Storage.Vector do
   def create_bucket(%__MODULE__{} = v, vector_bucket_name)
       when is_binary(vector_bucket_name) do
     v.client
-    |> Storage.Request.base("/CreateVectorBucket")
+    |> Storage.Request.base("/vector/CreateVectorBucket")
     |> Request.with_method(:post)
-    |> Request.with_body(%{vector_bucket_name: vector_bucket_name})
+    |> Request.with_body(%{vectorBucketName: vector_bucket_name})
     |> Fetcher.request()
     |> then(fn
       {:ok, _} -> {:ok, :created}
@@ -179,9 +179,9 @@ defmodule Supabase.Storage.Vector do
   def get_bucket(%__MODULE__{} = v, vector_bucket_name)
       when is_binary(vector_bucket_name) do
     v.client
-    |> Storage.Request.base("/GetVectorBucket")
+    |> Storage.Request.base("/vector/GetVectorBucket")
     |> Request.with_method(:post)
-    |> Request.with_body(%{vector_bucket_name: vector_bucket_name})
+    |> Request.with_body(%{vectorBucketName: vector_bucket_name})
     |> Request.with_body_decoder(BodyDecoder, schema: Metadata)
     |> Fetcher.request()
   end
@@ -220,10 +220,18 @@ defmodule Supabase.Storage.Vector do
   """
   @impl true
   def list_buckets(%__MODULE__{} = v, options \\ %{max_results: 100}) do
+    options = Map.new(options)
+
+    body =
+      %{}
+      |> maybe_put(:prefix, options[:prefix])
+      |> maybe_put(:maxResults, options[:max_results])
+      |> maybe_put(:nextToken, options[:next_token])
+
     v.client
-    |> Storage.Request.base("/ListVectorBuckets")
+    |> Storage.Request.base("/vector/ListVectorBuckets")
     |> Request.with_method(:post)
-    |> Request.with_body(options)
+    |> Request.with_body(body)
     |> Fetcher.request()
   end
 
@@ -255,9 +263,9 @@ defmodule Supabase.Storage.Vector do
   def delete_bucket(%__MODULE__{} = v, vector_bucket_name)
       when is_binary(vector_bucket_name) do
     v.client
-    |> Storage.Request.base("/DeleteVectorBucket")
+    |> Storage.Request.base("/vector/DeleteVectorBucket")
     |> Request.with_method(:post)
-    |> Request.with_body(%{vector_bucket_name: vector_bucket_name})
+    |> Request.with_body(%{vectorBucketName: vector_bucket_name})
     |> Fetcher.request()
     |> then(fn
       {:ok, _} -> {:ok, :deleted}
@@ -310,9 +318,29 @@ defmodule Supabase.Storage.Vector do
 
     changeset = Index.create_changeset(%Index{}, params)
 
-    with {:ok, body} <- Ecto.Changeset.apply_action(changeset, :create) do
+    with {:ok, index} <- Ecto.Changeset.apply_action(changeset, :create) do
+      body = %{
+        vectorBucketName: index.vector_bucket_name,
+        indexName: index.index_name,
+        dataType: index.data_type,
+        dimension: index.dimension,
+        distanceMetric: index.distance_metric
+      }
+
+      body =
+        case index.metadata_configuration do
+          nil ->
+            body
+
+          config ->
+            metadata_configuration =
+              maybe_put(%{}, :nonFilterableMetadataKeys, config.non_filterable_metadata_keys)
+
+            Map.put(body, :metadataConfiguration, metadata_configuration)
+        end
+
       v.client
-      |> Storage.Request.base("/CreateIndex")
+      |> Storage.Request.base("/vector/CreateIndex")
       |> Request.with_method(:post)
       |> Request.with_body(body)
       |> Fetcher.request()
@@ -356,9 +384,9 @@ defmodule Supabase.Storage.Vector do
   def get_index(%__MODULE__{} = v, index_name)
       when not is_nil(v.vector_bucket_name) and is_binary(index_name) do
     v.client
-    |> Storage.Request.base("/GetIndex")
+    |> Storage.Request.base("/vector/GetIndex")
     |> Request.with_method(:post)
-    |> Request.with_body(%{vector_bucket_name: v.vector_bucket_name, index_name: index_name})
+    |> Request.with_body(%{vectorBucketName: v.vector_bucket_name, indexName: index_name})
     |> Request.with_body_decoder(BodyDecoder, schema: Index)
     |> Fetcher.request()
   end
@@ -395,15 +423,18 @@ defmodule Supabase.Storage.Vector do
   @impl true
   def list_indexes(%__MODULE__{} = v, options \\ %{max_results: 100})
       when not is_nil(v.vector_bucket_name) do
-    options =
-      options
-      |> Map.new()
-      |> Map.put_new(:vector_bucket_name, v.vector_bucket_name)
+    options = Map.new(options)
+
+    body =
+      %{vectorBucketName: v.vector_bucket_name}
+      |> maybe_put(:prefix, options[:prefix])
+      |> maybe_put(:maxResults, options[:max_results])
+      |> maybe_put(:nextToken, options[:next_token])
 
     v.client
-    |> Storage.Request.base("/ListIndexes")
+    |> Storage.Request.base("/vector/ListIndexes")
     |> Request.with_method(:post)
-    |> Request.with_body(options)
+    |> Request.with_body(body)
     |> Fetcher.request()
   end
 
@@ -432,13 +463,16 @@ defmodule Supabase.Storage.Vector do
   def delete_index(%__MODULE__{} = v, index_name)
       when not is_nil(v.vector_bucket_name) and is_binary(index_name) do
     v.client
-    |> Storage.Request.base("/DeleteIndex")
+    |> Storage.Request.base("/vector/DeleteIndex")
     |> Request.with_method(:post)
-    |> Request.with_body(%{vector_bucket_name: v.vector_bucket_name, index_name: index_name})
+    |> Request.with_body(%{vectorBucketName: v.vector_bucket_name, indexName: index_name})
     |> Fetcher.request()
     |> then(fn
       {:ok, _} -> {:ok, :deleted}
       err -> err
     end)
   end
+
+  defp maybe_put(map, _key, nil), do: map
+  defp maybe_put(map, key, value), do: Map.put(map, key, value)
 end

--- a/lib/supabase/storage/vector/index.ex
+++ b/lib/supabase/storage/vector/index.ex
@@ -131,17 +131,17 @@ defmodule Supabase.Storage.Vector.Index do
   @impl true
   def put_vectors(%Vector{} = v, params \\ %{})
       when not (is_nil(v.vector_bucket_name) or is_nil(v.vector_index_name)) do
-    params =
-      params
-      |> Map.new()
-      |> Map.put_new(:vector_bucket_name, v.vector_bucket_name)
-      |> Map.put_new(:index_name, v.vector_index_name)
+    with {:ok, %{vectors: vectors}} <- validate_put_vectors(Map.new(params)) do
+      body = %{
+        vectorBucketName: v.vector_bucket_name,
+        indexName: v.vector_index_name,
+        vectors: vectors
+      }
 
-    with {:ok, params} <- validate_put_vectors(params) do
       v.client
-      |> Storage.Request.base("/PutVectors")
+      |> Storage.Request.base("/vector/PutVectors")
       |> Request.with_method(:post)
-      |> Request.with_body(params)
+      |> Request.with_body(body)
       |> Fetcher.request()
       |> then(fn
         {:ok, _} -> {:ok, :put}
@@ -180,16 +180,18 @@ defmodule Supabase.Storage.Vector.Index do
   @impl true
   def get_vectors(%Vector{} = v, opts \\ %{})
       when not (is_nil(v.vector_bucket_name) or is_nil(v.vector_index_name)) do
-    opts =
-      opts
-      |> Map.new()
-      |> Map.put_new(:vector_bucket_name, v.vector_bucket_name)
-      |> Map.put_new(:index_name, v.vector_index_name)
+    opts = Map.new(opts)
+
+    body =
+      %{vectorBucketName: v.vector_bucket_name, indexName: v.vector_index_name}
+      |> maybe_put(:keys, opts[:keys])
+      |> maybe_put(:returnData, opts[:return_data])
+      |> maybe_put(:returnMetadata, opts[:return_metadata])
 
     v.client
-    |> Storage.Request.base("/GetVectors")
+    |> Storage.Request.base("/vector/GetVectors")
     |> Request.with_method(:post)
-    |> Request.with_body(opts)
+    |> Request.with_body(body)
     |> Fetcher.request()
   end
 
@@ -226,17 +228,22 @@ defmodule Supabase.Storage.Vector.Index do
   """
   @impl true
   def list_vectors(%Vector{} = v, opts \\ %{}) do
-    opts =
-      opts
-      |> Map.new()
-      |> Map.put_new(:vector_bucket_name, v.vector_bucket_name)
-      |> Map.put_new(:index_name, v.vector_index_name)
+    opts = Map.new(opts)
 
     with {:ok, opts} <- validate_list_vectors(opts) do
+      body =
+        %{vectorBucketName: v.vector_bucket_name, indexName: v.vector_index_name}
+        |> maybe_put(:maxResults, opts[:max_results])
+        |> maybe_put(:nextToken, opts[:next_token])
+        |> maybe_put(:returnData, opts[:return_data])
+        |> maybe_put(:returnMetadata, opts[:return_metadata])
+        |> maybe_put(:segmentCount, opts[:segment_count])
+        |> maybe_put(:segmentIndex, opts[:segment_index])
+
       v.client
-      |> Storage.Request.base("/ListVectors")
+      |> Storage.Request.base("/vector/ListVectors")
       |> Request.with_method(:post)
-      |> Request.with_body(opts)
+      |> Request.with_body(body)
       |> Fetcher.request()
     end
   end
@@ -280,16 +287,20 @@ defmodule Supabase.Storage.Vector.Index do
   @impl true
   def query_vector(%Vector{} = v, query \\ %{})
       when not (is_nil(v.vector_bucket_name) or is_nil(v.vector_index_name)) do
-    query =
-      query
-      |> Map.new()
-      |> Map.put_new(:vector_bucket_name, v.vector_bucket_name)
-      |> Map.put_new(:index_name, v.vector_index_name)
+    query = Map.new(query)
+
+    body =
+      %{vectorBucketName: v.vector_bucket_name, indexName: v.vector_index_name}
+      |> maybe_put(:queryVector, query[:query_vector])
+      |> maybe_put(:topK, query[:topK])
+      |> maybe_put(:filter, query[:filter])
+      |> maybe_put(:returnDistance, query[:return_distance])
+      |> maybe_put(:returnMetadata, query[:return_metadata])
 
     v.client
-    |> Storage.Request.base("/QueryVectors")
+    |> Storage.Request.base("/vector/QueryVectors")
     |> Request.with_method(:post)
-    |> Request.with_body(query)
+    |> Request.with_body(body)
     |> Fetcher.request()
   end
 
@@ -318,11 +329,11 @@ defmodule Supabase.Storage.Vector.Index do
       when not (is_nil(v.vector_bucket_name) or is_nil(v.vector_index_name)) and is_list(keys) do
     with {:ok, _} <- validate_delete_vectors(keys) do
       v.client
-      |> Storage.Request.base("/DeleteVectors")
+      |> Storage.Request.base("/vector/DeleteVectors")
       |> Request.with_method(:post)
       |> Request.with_body(%{
-        vector_bucket_name: v.vector_bucket_name,
-        index_name: v.vector_index_name,
+        vectorBucketName: v.vector_bucket_name,
+        indexName: v.vector_index_name,
         keys: keys
       })
       |> Fetcher.request()
@@ -350,8 +361,39 @@ defmodule Supabase.Storage.Vector.Index do
 
   def parse(attrs) do
     %__MODULE__{}
-    |> changeset(attrs)
+    |> changeset(normalize_response(attrs))
     |> apply_action(:parse)
+  end
+
+  # The vectors API returns camelCase JSON keys; translate the known
+  # response keys to the snake_case fields before casting.
+  defp normalize_response(attrs) when is_map(attrs) do
+    attrs
+    |> rename_key("indexName", "index_name")
+    |> rename_key("vectorBucketName", "vector_bucket_name")
+    |> rename_key("dataType", "data_type")
+    |> rename_key("distanceMetric", "distance_metric")
+    |> rename_key("creationTime", "creation_time")
+    |> normalize_metadata_configuration()
+  end
+
+  defp normalize_metadata_configuration(attrs) do
+    case Map.pop(attrs, "metadataConfiguration") do
+      {nil, attrs} ->
+        attrs
+
+      {config, attrs} when is_map(config) ->
+        config = rename_key(config, "nonFilterableMetadataKeys", "non_filterable_metadata_keys")
+
+        Map.put(attrs, "metadata_configuration", config)
+    end
+  end
+
+  defp rename_key(map, from, to) do
+    case Map.pop(map, from) do
+      {nil, map} -> map
+      {value, map} -> Map.put(map, to, value)
+    end
   end
 
   def changeset(%__MODULE__{} = i, %{} = attrs) do
@@ -435,4 +477,7 @@ defmodule Supabase.Storage.Vector.Index do
       changeset
     end
   end
+
+  defp maybe_put(map, _key, nil), do: map
+  defp maybe_put(map, key, value), do: Map.put(map, key, value)
 end

--- a/lib/supabase/storage/vector/metadata.ex
+++ b/lib/supabase/storage/vector/metadata.ex
@@ -58,8 +58,39 @@ defmodule Supabase.Storage.Vector.Metadata do
 
   def parse(attrs) do
     %__MODULE__{}
-    |> changeset(attrs)
+    |> changeset(normalize_response(attrs))
     |> apply_action(:parse)
+  end
+
+  # The vectors API returns camelCase JSON keys; translate the known
+  # response keys to the snake_case fields before casting.
+  defp normalize_response(attrs) when is_map(attrs) do
+    attrs
+    |> rename_key("vectorBucketName", "vector_bucket_name")
+    |> rename_key("creationTime", "creation_time")
+    |> normalize_encryption_configuration()
+  end
+
+  defp normalize_encryption_configuration(attrs) do
+    case Map.pop(attrs, "encryptionConfiguration") do
+      {nil, attrs} ->
+        attrs
+
+      {config, attrs} when is_map(config) ->
+        config =
+          config
+          |> rename_key("kmsKeyArn", "kms_key_arn")
+          |> rename_key("sseType", "sse_type")
+
+        Map.put(attrs, "encryption_configuration", config)
+    end
+  end
+
+  defp rename_key(map, from, to) do
+    case Map.pop(map, from) do
+      {nil, map} -> map
+      {value, map} -> Map.put(map, to, value)
+    end
   end
 
   @doc """

--- a/test/supabase/storage/vector/index_test.exs
+++ b/test/supabase/storage/vector/index_test.exs
@@ -23,8 +23,23 @@ defmodule Supabase.Storage.Vector.IndexTest do
   describe "put_vectors/2" do
     test "it should insert vectors successfully", %{client: client} do
       @mock
-      |> expect(:request, fn %Request{url: url, body: _body}, _opts ->
-        assert String.ends_with?(url.path, "/PutVectors")
+      |> expect(:request, fn %Request{url: url, body: body}, _opts ->
+        assert String.ends_with?(url.path, "/vector/PutVectors")
+
+        body = body |> IO.iodata_to_binary() |> Jason.decode!()
+
+        assert body["vectorBucketName"] == "embeddings"
+        assert body["indexName"] == "documents"
+        refute Map.has_key?(body, "vector_bucket_name")
+        refute Map.has_key?(body, "index_name")
+
+        assert [
+                 %{
+                   "key" => "doc-1",
+                   "data" => %{"float32" => [0.1, 0.2, 0.3]},
+                   "metadata" => %{"title" => "Intro"}
+                 }
+               ] = body["vectors"]
 
         {:ok, %Finch.Response{status: 200, headers: [], body: ~s({})}}
       end)
@@ -67,8 +82,17 @@ defmodule Supabase.Storage.Vector.IndexTest do
   describe "get_vectors/2" do
     test "it should retrieve vectors by keys", %{client: client} do
       @mock
-      |> expect(:request, fn %Request{url: url, body: _body}, _opts ->
-        assert String.ends_with?(url.path, "/GetVectors")
+      |> expect(:request, fn %Request{url: url, body: body}, _opts ->
+        assert String.ends_with?(url.path, "/vector/GetVectors")
+
+        body = body |> IO.iodata_to_binary() |> Jason.decode!()
+
+        assert body["vectorBucketName"] == "embeddings"
+        assert body["indexName"] == "documents"
+        assert body["keys"] == ["doc-1"]
+        assert body["returnData"] == true
+        assert body["returnMetadata"] == true
+        refute Map.has_key?(body, "vector_bucket_name")
 
         response_body = """
         {
@@ -103,8 +127,15 @@ defmodule Supabase.Storage.Vector.IndexTest do
   describe "list_vectors/2" do
     test "it should list vectors with pagination", %{client: client} do
       @mock
-      |> expect(:request, fn %Request{url: url}, _opts ->
-        assert String.ends_with?(url.path, "/ListVectors")
+      |> expect(:request, fn %Request{url: url, body: body}, _opts ->
+        assert String.ends_with?(url.path, "/vector/ListVectors")
+
+        body = body |> IO.iodata_to_binary() |> Jason.decode!()
+
+        assert body["vectorBucketName"] == "embeddings"
+        assert body["indexName"] == "documents"
+        assert body["maxResults"] == 100
+        refute Map.has_key?(body, "max_results")
 
         response_body = """
         {
@@ -158,8 +189,18 @@ defmodule Supabase.Storage.Vector.IndexTest do
   describe "query_vector/2" do
     test "it should query similar vectors", %{client: client} do
       @mock
-      |> expect(:request, fn %Request{url: url, body: _body}, _opts ->
-        assert String.ends_with?(url.path, "/QueryVectors")
+      |> expect(:request, fn %Request{url: url, body: body}, _opts ->
+        assert String.ends_with?(url.path, "/vector/QueryVectors")
+
+        body = body |> IO.iodata_to_binary() |> Jason.decode!()
+
+        assert body["vectorBucketName"] == "embeddings"
+        assert body["indexName"] == "documents"
+        assert body["queryVector"] == %{"float32" => [0.1, 0.2, 0.3]}
+        assert body["topK"] == 5
+        assert body["returnDistance"] == true
+        assert body["returnMetadata"] == true
+        refute Map.has_key?(body, "query_vector")
 
         response_body = """
         {
@@ -197,8 +238,15 @@ defmodule Supabase.Storage.Vector.IndexTest do
   describe "delete_vectors/2" do
     test "it should delete vectors by keys", %{client: client} do
       @mock
-      |> expect(:request, fn %Request{url: url, body: _body}, _opts ->
-        assert String.ends_with?(url.path, "/DeleteVectors")
+      |> expect(:request, fn %Request{url: url, body: body}, _opts ->
+        assert String.ends_with?(url.path, "/vector/DeleteVectors")
+
+        body = body |> IO.iodata_to_binary() |> Jason.decode!()
+
+        assert body["vectorBucketName"] == "embeddings"
+        assert body["indexName"] == "documents"
+        assert body["keys"] == ["doc-1", "doc-2"]
+        refute Map.has_key?(body, "vector_bucket_name")
 
         {:ok, %Finch.Response{status: 200, headers: [], body: ~s({})}}
       end)
@@ -226,6 +274,33 @@ defmodule Supabase.Storage.Vector.IndexTest do
       keys = Enum.map(1..501, fn i -> "doc-#{i}" end)
 
       assert {:error, %Ecto.Changeset{}} = Index.delete_vectors(index, keys)
+    end
+  end
+
+  describe "parse/1" do
+    test "it should parse a camelCase GetIndex response into the struct" do
+      attrs = %{
+        "indexName" => "documents-openai",
+        "vectorBucketName" => "embeddings",
+        "dataType" => "float32",
+        "dimension" => 1536,
+        "distanceMetric" => "cosine",
+        "creationTime" => 1_704_067_200,
+        "metadataConfiguration" => %{
+          "nonFilterableMetadataKeys" => ["raw_text"]
+        }
+      }
+
+      assert {:ok, %Index{} = index} = Index.parse(attrs)
+      assert index.index_name == "documents-openai"
+      assert index.vector_bucket_name == "embeddings"
+      assert index.data_type == :float32
+      assert index.dimension == 1536
+      assert index.distance_metric == :cosine
+      assert index.creation_time == 1_704_067_200
+
+      assert %Index.MetadataConfiguration{non_filterable_metadata_keys: ["raw_text"]} =
+               index.metadata_configuration
     end
   end
 end

--- a/test/supabase/storage/vector_test.exs
+++ b/test/supabase/storage/vector_test.exs
@@ -4,6 +4,7 @@ defmodule Supabase.Storage.VectorTest do
   alias Supabase.Fetcher.Request
   alias Supabase.Fetcher.Response
   alias Supabase.Storage.Vector
+  alias Supabase.Storage.Vector.Metadata
 
   import Mox
 
@@ -36,8 +37,13 @@ defmodule Supabase.Storage.VectorTest do
   describe "create_bucket/2" do
     test "it should create a vector bucket successfully", %{client: client} do
       @mock
-      |> expect(:request, fn %Request{url: url, body: _body}, _opts ->
-        assert String.ends_with?(url.path, "/CreateVectorBucket")
+      |> expect(:request, fn %Request{url: url, body: body}, _opts ->
+        assert String.ends_with?(url.path, "/vector/CreateVectorBucket")
+
+        body = body |> IO.iodata_to_binary() |> Jason.decode!()
+
+        assert body["vectorBucketName"] == "embeddings"
+        refute Map.has_key?(body, "vector_bucket_name")
 
         {:ok, %Finch.Response{status: 200, headers: [], body: ~s({})}}
       end)
@@ -63,8 +69,13 @@ defmodule Supabase.Storage.VectorTest do
   describe "get_bucket/2" do
     test "it should return bucket metadata when bucket exists", %{client: client} do
       @mock
-      |> expect(:request, fn %Request{url: url, body: _body}, _opts ->
-        assert String.ends_with?(url.path, "/GetVectorBucket")
+      |> expect(:request, fn %Request{url: url, body: body}, _opts ->
+        assert String.ends_with?(url.path, "/vector/GetVectorBucket")
+
+        body = body |> IO.iodata_to_binary() |> Jason.decode!()
+
+        assert body["vectorBucketName"] == "embeddings"
+        refute Map.has_key?(body, "vector_bucket_name")
 
         response_body = """
         {
@@ -111,7 +122,7 @@ defmodule Supabase.Storage.VectorTest do
     test "it should list vector buckets with empty result", %{client: client} do
       @mock
       |> expect(:request, fn %Request{url: url}, _opts ->
-        assert String.ends_with?(url.path, "/ListVectorBuckets")
+        assert String.ends_with?(url.path, "/vector/ListVectorBuckets")
 
         response_body = """
         {
@@ -176,7 +187,14 @@ defmodule Supabase.Storage.VectorTest do
 
     test "it should list vector buckets with pagination", %{client: client} do
       @mock
-      |> expect(:request, fn %Request{body: _body}, _opts ->
+      |> expect(:request, fn %Request{body: body}, _opts ->
+        body = body |> IO.iodata_to_binary() |> Jason.decode!()
+
+        assert body["maxResults"] == 50
+        assert body["nextToken"] == "previous-token"
+        refute Map.has_key?(body, "max_results")
+        refute Map.has_key?(body, "next_token")
+
         response_body = """
         {
           "vectorBuckets": [
@@ -203,7 +221,7 @@ defmodule Supabase.Storage.VectorTest do
     test "it should delete a vector bucket successfully", %{client: client} do
       @mock
       |> expect(:request, fn %Request{url: url, body: _body}, _opts ->
-        assert String.ends_with?(url.path, "/DeleteVectorBucket")
+        assert String.ends_with?(url.path, "/vector/DeleteVectorBucket")
 
         {:ok, %Finch.Response{status: 200, headers: [], body: ~s({})}}
       end)
@@ -259,8 +277,18 @@ defmodule Supabase.Storage.VectorTest do
   describe "create_index/2" do
     test "it should create an index successfully", %{client: client} do
       @mock
-      |> expect(:request, fn %Request{url: url, body: _body}, _opts ->
-        assert String.ends_with?(url.path, "/CreateIndex")
+      |> expect(:request, fn %Request{url: url, body: body}, _opts ->
+        assert String.ends_with?(url.path, "/vector/CreateIndex")
+
+        body = body |> IO.iodata_to_binary() |> Jason.decode!()
+
+        assert body["vectorBucketName"] == "embeddings"
+        assert body["indexName"] == "documents-openai"
+        assert body["dataType"] == "float32"
+        assert body["dimension"] == 1536
+        assert body["distanceMetric"] == "cosine"
+        refute Map.has_key?(body, "vector_bucket_name")
+        refute Map.has_key?(body, "index_name")
 
         {:ok, %Finch.Response{status: 200, headers: [], body: ~s({})}}
       end)
@@ -289,8 +317,14 @@ defmodule Supabase.Storage.VectorTest do
   describe "get_index/2" do
     test "it should return index metadata when index exists", %{client: client} do
       @mock
-      |> expect(:request, fn %Request{url: url, body: _body}, _opts ->
-        assert String.ends_with?(url.path, "/GetIndex")
+      |> expect(:request, fn %Request{url: url, body: body}, _opts ->
+        assert String.ends_with?(url.path, "/vector/GetIndex")
+
+        body = body |> IO.iodata_to_binary() |> Jason.decode!()
+
+        assert body["vectorBucketName"] == "embeddings"
+        assert body["indexName"] == "documents-openai"
+        refute Map.has_key?(body, "vector_bucket_name")
 
         response_body = """
         {
@@ -336,7 +370,7 @@ defmodule Supabase.Storage.VectorTest do
     test "it should list indexes with empty result", %{client: client} do
       @mock
       |> expect(:request, fn %Request{url: url}, _opts ->
-        assert String.ends_with?(url.path, "/ListIndexes")
+        assert String.ends_with?(url.path, "/vector/ListIndexes")
 
         response_body = """
         {
@@ -403,7 +437,7 @@ defmodule Supabase.Storage.VectorTest do
     test "it should delete an index successfully", %{client: client} do
       @mock
       |> expect(:request, fn %Request{url: url, body: _body}, _opts ->
-        assert String.ends_with?(url.path, "/DeleteIndex")
+        assert String.ends_with?(url.path, "/vector/DeleteIndex")
 
         {:ok, %Finch.Response{status: 200, headers: [], body: ~s({})}}
       end)
@@ -424,6 +458,28 @@ defmodule Supabase.Storage.VectorTest do
       assert {:error, %Supabase.Error{} = err} = Vector.delete_index(vector, "nonexistent")
       assert err.code == :not_found
       assert err.message == "Index not found"
+    end
+  end
+
+  describe "Metadata.parse/1" do
+    test "it should parse a camelCase GetVectorBucket response into the struct" do
+      attrs = %{
+        "vectorBucketName" => "embeddings",
+        "creationTime" => 1_704_067_200,
+        "encryptionConfiguration" => %{
+          "kmsKeyArn" => "arn:aws:kms:us-east-1:123456789012:key/12345678",
+          "sseType" => "KMS"
+        }
+      }
+
+      assert {:ok, %Metadata{} = metadata} = Metadata.parse(attrs)
+      assert metadata.vector_bucket_name == "embeddings"
+      assert metadata.creation_time == 1_704_067_200
+
+      assert %Metadata.EncryptConfiguration{
+               kms_key_arn: "arn:aws:kms:us-east-1:123456789012:key/12345678",
+               sse_type: "KMS"
+             } = metadata.encryption_configuration
     end
   end
 end


### PR DESCRIPTION
## Problem

The vector buckets API released in 0.6.0 speaks the wrong wire format. Requests hit `{storage_url}/CreateVectorBucket` and friends without the required `/vector` prefix, request bodies are sent snake_case while the API expects camelCase, and response parsing casts snake_case fields while the server returns camelCase JSON, so `Metadata.parse/1` and `Index.parse/1` silently failed and the body decoder fell back to raw maps.

## Solution

- Prefix all 13 vector endpoints with `/vector` (bucket, index, and vector data operations).
- Translate snake_case Elixir options to camelCase wire keys explicitly at each call site; user-supplied vector `metadata` maps pass through untouched.
- Build the `CreateIndex` wire map explicitly from the validated changeset struct, keeping the existing validation.
- Normalize the known camelCase response keys to snake_case in `Metadata.parse/1` and `Index.parse/1` before the changeset cast (explicit key list, no generic inflector).
- Tighten tests to assert the `/vector/` prefix and decode request bodies to assert camelCase keys, and add decode tests asserting a camelCase GetVectorBucket/GetIndex response parses into the struct.

## Rationale

Matches the official JS client and the storage OpenAPI spec: base URL `{storage_url}/vector`, all bodies camelCase. The public API is unchanged (function names, arities, snake_case option keys); translation is explicit per call site instead of a generic deep-camelize helper so user metadata maps are never rewritten.